### PR TITLE
Keep Dependabot updates within major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## What changed

Keep automatic dependency proposals within the current major version.

## Why

The initial configuration immediately proposed ESLint 10 and Tailwind 4 migrations. Those are deliberate engineering projects rather than routine maintenance and should not crowd out safe monthly updates.

## Validation

- parsed the Dependabot YAML successfully
- git diff whitespace check passed
